### PR TITLE
Adds SpringDoc dependency for OpenAPI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-rest</artifactId>
 		</dependency>
+		<!-- Add dependency for Spring Doc -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Integrates the `springdoc-openapi-starter-webmvc-ui` dependency (version 2.8.9) to enable OpenAPI documentation generation for the project. Enhances API documentation capabilities.